### PR TITLE
Removed space between [] and () in google link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Rega-repo
 How to work with Github
 
-*Hello* **everyone**. What's up? 
-[link to google!] (http://google.com)
+*Hello* **everyone**. What's up?
+[link to google!](http://google.com)
 
 
 ## Subtitle
 Test
 # This is an <h1> tag
 ## This is an <h2> tag
-###### This is an <h6> tag  
+###### This is an <h6> tag
 
 ```javascript
 function fancyAlert (arg) {


### PR DESCRIPTION
Hi Hiwa!

I fixed an issue in your Markdown where the link to Google was not working, because of an extraneous space character.